### PR TITLE
[BE] MainPage를 위한 dailyQuiz 응답 로직 수정

### DIFF
--- a/Backend/src/main/java/com/ecobyte/ecocycle/application/UserService.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/application/UserService.java
@@ -1,9 +1,11 @@
 package com.ecobyte.ecocycle.application;
 
+import com.ecobyte.ecocycle.domain.quiz.DailyQuizRepository;
 import com.ecobyte.ecocycle.domain.user.User;
 import com.ecobyte.ecocycle.domain.user.UserRepository;
 import com.ecobyte.ecocycle.dto.response.MainPageResponse;
 import com.ecobyte.ecocycle.exception.UserNotFoundException;
+import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,15 +14,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final DailyQuizRepository dailyQuizRepository;
 
-    public UserService(final UserRepository userRepository) {
+    public UserService(final UserRepository userRepository,
+                       final DailyQuizRepository dailyQuizRepository) {
         this.userRepository = userRepository;
+        this.dailyQuizRepository = dailyQuizRepository;
     }
 
     public MainPageResponse findMyMainPage(final Long loginId) {
         final User loginUser = userRepository.findById(loginId)
                 .orElseThrow(UserNotFoundException::new);
 
-        return new MainPageResponse(loginUser.getNickname(), loginUser.getStamps(), false);
+        final boolean alreadyDailyQuiz = dailyQuizRepository.existsByUserIdAndAttendanceDate(loginId, LocalDate.now());
+        return new MainPageResponse(loginUser.getNickname(), loginUser.getStamps(), alreadyDailyQuiz);
     }
 }


### PR DESCRIPTION
Close #14 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
refactor/be/find-user-info -> main

## 요구사항
- main page 응답 시 그 날의 데일리 퀴즈를 풀었는지 응답한다.

## 변경사항
- 기존에 false로 하드 코딩 되었던 부분을 기능 로직에 맞게 수정

