### PR TITLE
[BE] 데일리 퀴즈 정답 여부를 기록하는 기능 구현

### DIFF
--- a/Backend/src/main/java/com/ecobyte/ecocycle/application/QuizService.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/application/QuizService.java
@@ -6,9 +6,12 @@ import com.ecobyte.ecocycle.domain.quiz.Quiz;
 import com.ecobyte.ecocycle.domain.quiz.QuizRepository;
 import com.ecobyte.ecocycle.domain.user.User;
 import com.ecobyte.ecocycle.domain.user.UserRepository;
+import com.ecobyte.ecocycle.dto.request.DailyQuizAnswerRequest;
 import com.ecobyte.ecocycle.dto.request.QuizRequest;
 import com.ecobyte.ecocycle.dto.response.QuizResponse;
 import com.ecobyte.ecocycle.exception.AlreadyExistedDailyQuizException;
+import com.ecobyte.ecocycle.exception.DailyQuizNotFoundException;
+import com.ecobyte.ecocycle.exception.DailyQuizOwnedException;
 import com.ecobyte.ecocycle.exception.NoQuizException;
 import com.ecobyte.ecocycle.exception.UserNotFoundException;
 import java.time.LocalDate;
@@ -44,6 +47,19 @@ public class QuizService {
 
         return QuizResponse.from(makeDailyQuiz(loginId, currentDate).getQuiz());
 
+    }
+
+    @Transactional
+    public void updateDailyAnswer(final Long loginId, final Long dailyQuizId,
+                                  final DailyQuizAnswerRequest dailyQuizAnswerRequest) {
+        final DailyQuiz dailyQuiz = dailyQuizRepository.findById(dailyQuizId)
+                .orElseThrow(DailyQuizNotFoundException::new);
+
+        if (!dailyQuiz.isOwnedBy(loginId)) {
+            throw new DailyQuizOwnedException();
+        }
+
+        dailyQuiz.updateAnswer(dailyQuizAnswerRequest.getIsRight());
     }
 
     private void checkDailyQuizAlreadyDid(final Long loginId, final LocalDate currentDate) {

--- a/Backend/src/main/java/com/ecobyte/ecocycle/domain/quiz/DailyQuiz.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/domain/quiz/DailyQuiz.java
@@ -49,4 +49,12 @@ public class DailyQuiz {
         this.isRight = false;
         this.attendanceDate = attendanceDate;
     }
+
+    public boolean isOwnedBy(final Long userId) {
+        return user.isSameId(userId);
+    }
+
+    public void updateAnswer(final boolean isRight) {
+        this.isRight = isRight;
+    }
 }

--- a/Backend/src/main/java/com/ecobyte/ecocycle/domain/quiz/DailyQuizRepository.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/domain/quiz/DailyQuizRepository.java
@@ -1,6 +1,7 @@
 package com.ecobyte.ecocycle.domain.quiz;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
 public interface DailyQuizRepository extends Repository<DailyQuiz, Long> {
@@ -8,4 +9,6 @@ public interface DailyQuizRepository extends Repository<DailyQuiz, Long> {
     DailyQuiz save(final DailyQuiz dailyQuiz);
 
     boolean existsByUserIdAndAttendanceDate(final Long userId, final LocalDate attendanceDate);
+
+    Optional<DailyQuiz> findById(final Long dailyQuizId);
 }

--- a/Backend/src/main/java/com/ecobyte/ecocycle/domain/user/User.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/domain/user/User.java
@@ -57,4 +57,8 @@ public class User {
     public boolean isAdmin() {
         return this.role == Role.ADMIN;
     }
+
+    public boolean isSameId(final Long userId) {
+        return id.equals(userId);
+    }
 }

--- a/Backend/src/main/java/com/ecobyte/ecocycle/dto/request/DailyQuizAnswerRequest.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/dto/request/DailyQuizAnswerRequest.java
@@ -1,0 +1,15 @@
+package com.ecobyte.ecocycle.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class DailyQuizAnswerRequest {
+
+    private Boolean isRight;
+
+    public DailyQuizAnswerRequest(final Boolean isRight) {
+        this.isRight = isRight;
+    }
+}

--- a/Backend/src/main/java/com/ecobyte/ecocycle/exception/DailyQuizNotFoundException.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/exception/DailyQuizNotFoundException.java
@@ -1,0 +1,16 @@
+package com.ecobyte.ecocycle.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DailyQuizNotFoundException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public DailyQuizNotFoundException() {
+        this.httpStatus = HttpStatus.NOT_FOUND;
+        this.message = "데일리 퀴즈 정보가 없습니다.";
+    }
+}

--- a/Backend/src/main/java/com/ecobyte/ecocycle/exception/DailyQuizOwnedException.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/exception/DailyQuizOwnedException.java
@@ -1,0 +1,16 @@
+package com.ecobyte.ecocycle.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DailyQuizOwnedException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public DailyQuizOwnedException() {
+        this.httpStatus = HttpStatus.BAD_REQUEST;
+        this.message = "데일리 퀴즈 소유자가 아닙니다.";
+    }
+}

--- a/Backend/src/main/java/com/ecobyte/ecocycle/presentation/ControllerAdvice.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/presentation/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.ecobyte.ecocycle.presentation;
 
 import com.ecobyte.ecocycle.dto.response.ErrorResponse;
 import com.ecobyte.ecocycle.exception.AlreadyExistedDailyQuizException;
+import com.ecobyte.ecocycle.exception.DailyQuizOwnedException;
 import com.ecobyte.ecocycle.exception.InvalidImageUrlException;
 import com.ecobyte.ecocycle.exception.NoDataException;
 import com.ecobyte.ecocycle.exception.NoQuizException;
@@ -46,6 +47,12 @@ public class ControllerAdvice {
     @ExceptionHandler(AlreadyExistedDailyQuizException.class)
     public ResponseEntity<ErrorResponse> handleAlreadyExistedDailyQuizException(
             final AlreadyExistedDailyQuizException exception) {
+        return ResponseEntity.status(exception.getHttpStatus())
+                .body(new ErrorResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(DailyQuizOwnedException.class)
+    public ResponseEntity<ErrorResponse> handleDailyQuizOwnedException(final DailyQuizOwnedException exception) {
         return ResponseEntity.status(exception.getHttpStatus())
                 .body(new ErrorResponse(exception.getMessage()));
     }

--- a/Backend/src/main/java/com/ecobyte/ecocycle/presentation/QuizController.java
+++ b/Backend/src/main/java/com/ecobyte/ecocycle/presentation/QuizController.java
@@ -2,12 +2,15 @@ package com.ecobyte.ecocycle.presentation;
 
 import com.ecobyte.ecocycle.application.QuizService;
 import com.ecobyte.ecocycle.application.auth.AdminAuthorization;
+import com.ecobyte.ecocycle.dto.request.DailyQuizAnswerRequest;
 import com.ecobyte.ecocycle.dto.request.QuizRequest;
 import com.ecobyte.ecocycle.dto.response.QuizResponse;
 import com.ecobyte.ecocycle.presentation.auth.AuthorizationPrincipal;
 import com.ecobyte.ecocycle.presentation.auth.LoginAuthorization;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +37,14 @@ public class QuizController {
     public ResponseEntity<QuizResponse> giveDailyQuiz(@AuthorizationPrincipal final Long loginId) {
         final QuizResponse quizResponse = quizService.giveDailyQuiz(loginId);
         return ResponseEntity.ok(quizResponse);
+    }
+
+    @PutMapping("/today/{dailyQuizId}")
+    public ResponseEntity<Void> updateDailyAnswer(@AuthorizationPrincipal final Long loginId,
+                                                  @PathVariable Long dailyQuizId,
+                                                  @RequestBody DailyQuizAnswerRequest dailyQuizAnswerRequest) {
+        quizService.updateDailyAnswer(loginId, dailyQuizId, dailyQuizAnswerRequest);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/Backend/src/test/java/com/ecobyte/ecocycle/acceptance/AcceptanceTest.java
+++ b/Backend/src/test/java/com/ecobyte/ecocycle/acceptance/AcceptanceTest.java
@@ -23,21 +23,16 @@ import org.springframework.http.MediaType;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
 
-    @Autowired
-    private UserRepository userRepository;
-
     @MockBean
     protected GoogleClient googleClient;
-
     @MockBean
     protected DataClassificationClient dataClassificationClient;
-
     @Value("${admin.email}")
     protected String adminEmail;
-
     @LocalServerPort
     int port;
-
+    @Autowired
+    private UserRepository userRepository;
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
@@ -79,6 +74,14 @@ public class AcceptanceTest {
                 .auth().oauth2(token)
                 .body(requestBody)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().post(uri)
+                .then().log().all();
+    }
+
+    protected ValidatableResponse post(final String uri, final String token) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(token)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().post(uri)
                 .then().log().all();


### PR DESCRIPTION
Close #72 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/ be/update-daily-quiz -> main

## 요구사항
- 데일리 퀴즈 정답 여부를 기록한다.
- 퀴즈에 맞는 유저가 아닌 경우 예외를 반환한다.
